### PR TITLE
Fix ubuntu version and mount volume

### DIFF
--- a/latex-emacs-min/Dockerfile
+++ b/latex-emacs-min/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 MAINTAINER oscar
 
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /data
-VOLUME ["data"]
+VOLUME ["/data"]
 
 COPY install-org.el /tmp/
 RUN emacs --batch --load /tmp/install-org.el


### PR DESCRIPTION
- Some package names in ubuntu:latest (20.04 now) have changed, so I have fixed the FROM to `ubuntu:18.04` (alternative would be to update the package names - specifically I noticed that `texlive-generic-recommended` was replaced by `texlive-plain-generic`, but I don't know if other things might also break down the chain).
- VOLUME without an absolute path does not work for me, I have fixed it  to `/data`.